### PR TITLE
Added new rule to Allow working on a Windows machine

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -1,23 +1,24 @@
 {
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-      "ecmaVersion": 2021,
-      "sourceType": "module"
+    "ecmaVersion": 2021,
+    "sourceType": "module"
   },
   "extends": [
-      "plugin:@typescript-eslint/recommended",
-      "plugin:react/recommended",
-      "plugin:prettier/recommended",
-      "plugin:react-hooks/recommended"
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended",
+    "plugin:prettier/recommended",
+    "plugin:react-hooks/recommended"
   ],
   "settings": {
-    "react": { "version": "detect"}
+    "react": { "version": "detect" }
   },
   "rules": {
     // suppress errors for missing 'import React' in files
-   "react/react-in-jsx-scope": "off",
-   "react/prop-types": "off",
-   "react-hooks/rules-of-hooks": "error",
-   "react-hooks/exhaustive-deps": "error"
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "error",
+    "prettier/prettier": ["error", { "endOfLine": "auto" }]
   }
 }


### PR DESCRIPTION
### What this PR does (required):
- Added a new rule to the rules object in the .eslintrc file to allow CRLF as the line ending format for developers like me using a Windows machine.
- Here is a screenshot of my console without the added rule
![eslint error](https://user-images.githubusercontent.com/53505772/133246377-fd2d2adb-16a7-4a7a-8fa2-72da383f188e.PNG)
- Here is a screenshot of my console after adding the rule
![added_new_eslint_rule](https://user-images.githubusercontent.com/53505772/133246729-ad215a16-b368-4415-9ac0-fc48db4c34fb.PNG)

